### PR TITLE
Fixed loading for single instrument page by adding new reducer

### DIFF
--- a/client/components/Instrument.js
+++ b/client/components/Instrument.js
@@ -10,6 +10,7 @@ export default class Instrument extends React.Component {
   }
 
   render() {
+    console.log(this.props)
     const { instrument } = this.props;
     return (
       <Grid.Column>

--- a/client/components/SingleInstrument.js
+++ b/client/components/SingleInstrument.js
@@ -12,7 +12,9 @@ const options = [
 // 
 
 export default class SingleInstrument extends React.Component {
-    componentDidMount() {
+    
+
+    componentDidMount() { 
         if (this.props.loadInstrument) {
             this.props.loadInstrument();
         }
@@ -20,7 +22,7 @@ export default class SingleInstrument extends React.Component {
 
     render() {
         console.log(this.props)
-        const { instrument } = this.props;
+        const { singleInstrument } = this.props;
         return (
             <div>
                 <Link to={'/instruments'}><h4>Back to all instruments</h4></Link>  {/* link to previous page, history or something */}
@@ -30,17 +32,17 @@ export default class SingleInstrument extends React.Component {
                     <Grid.Column width={12}>
                     <Grid celled>
                         <Grid.Column width={3}>
-                            <Image src={instrument.imageUrl} />
+                            <Image src={singleInstrument && singleInstrument.imageUrl} />
                         </Grid.Column>
                         <Grid.Column width={8}>
                             <Grid.Row>
-                                <h3>Name: {instrument.name}</h3>
+                                <h3>Name: {singleInstrument && singleInstrument.name}</h3>
                             </Grid.Row>
                             <Grid.Row>
-                                <h3>Price: {instrument.price}</h3>
+                                <h3>Price: {singleInstrument && singleInstrument.price}</h3>
                             </Grid.Row>
                             <Grid.Row>
-                                <h3>Rating: {instrument.rating} </h3>
+                                <h3>Rating: {singleInstrument && singleInstrument.rating} </h3>
                             </Grid.Row>
                             <Grid.Row>
                                 <h3>Quantity:

--- a/client/containers/SingleInstrumentContainer.js
+++ b/client/containers/SingleInstrumentContainer.js
@@ -1,16 +1,15 @@
 import { connect } from 'react-redux';
 
 import SingleInstrument from '../components/SingleInstrument';
-import { fetchOneInstrument } from '../store';
+import { fetchSingleInstrument } from '../store';
 
 const mapStateToProps = (storeState, ownProps) => ({
-    instrument: storeState.instruments.find(instrument => +ownProps.match.params.id === +instrument.id)
+    singleInstrument: storeState.singleInstrument
   });
   
   const mapDispatchToProps = (dispatch, ownProps) => ({
     loadInstrument: () => {
-      console.log(ownProps.match.params.id);
-      const action = fetchOneInstrument(ownProps.match.params.id);
+      const action = fetchSingleInstrument(+(ownProps.match.params.id));
       return dispatch(action);
     }
   });

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -3,10 +3,11 @@ import createLogger from 'redux-logger'
 import thunkMiddleware from 'redux-thunk'
 import {composeWithDevTools} from 'redux-devtools-extension'
 import user from './reducers/user'
-import instruments from './reducers/instrument'
+import instruments from './reducers/instruments'
 import topFive from './reducers/topFive'
+import singleInstrument from './reducers/singleInstrument'
 
-export const reducer = combineReducers({user, instruments, topFive})
+export const reducer = combineReducers({user, instruments, topFive, singleInstrument})
 const middleware = composeWithDevTools(applyMiddleware(
   thunkMiddleware,
   createLogger({collapsed: true})
@@ -15,6 +16,7 @@ const store = createStore(reducer, middleware)
 
 export default store
 export * from './reducers/user'
-export * from './reducers/instrument'
+export * from './reducers/instruments'
 export * from './reducers/topFive'
+export * from './reducers/singleInstrument'
 

--- a/client/store/reducers/instruments.js
+++ b/client/store/reducers/instruments.js
@@ -15,6 +15,7 @@ export const upsertInstrument = instrument => ({
   singleInstrument: instrument
 })
 
+
 //THUNK CREATORS
 export const fetchInstruments = () => {
   return dispatch => {
@@ -39,6 +40,7 @@ export const fetchOneInstrument = id => {
       });
   };
 };
+
 
 //REDUCER
 export default function instrumentReducer(state = [], action) {

--- a/client/store/reducers/singleInstrument.js
+++ b/client/store/reducers/singleInstrument.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+// ACTION TYPES 
+const GET_SINGLE_INSTRUMENT = 'GET_SINGLE_INSTRUMENT';
+
+// ACTION CREATORS
+
+export const getSingleInstrument = instrument => ({
+    type: GET_SINGLE_INSTRUMENT,
+    instrument: instrument
+})
+
+// THUNKS
+
+export const fetchSingleInstrument = id => {
+    return dispatch => {
+        return axios
+            .get(`/api/instruments/${id}`)
+            .then(res => res.data)
+            .then(instrument => {
+                const action = getSingleInstrument(instrument);
+                dispatch(action);
+            });
+    }
+}
+
+// REDUCER
+
+export default function reducer(state = {}, action) {
+    switch (action.type) {
+        case GET_SINGLE_INSTRUMENT:
+            return action.instrument
+        default:
+            return state;
+    }
+}

--- a/server/api/instruments.js
+++ b/server/api/instruments.js
@@ -17,18 +17,14 @@ router.get('/', (req, res, next) => {
 router.get('/top-five', (req, res, next) => {
   Instrument.findAll()
   .then( instruments => {
-      return Instrument.getTopRating(instruments)
+    return Instrument.getTopRating(instruments)
   })
   .then(topFive => res.json(topFive))
   .catch(next);
 });
 
 router.get('/:id', (req, res, next) => {
-  Instrument.findAll({
-    where: {
-      id: req.params.id
-    }
-  })
+  Instrument.findById(req.params.id)
   .then( instrument => {
     if (instrument){
       res.status(200).json(instrument);


### PR DESCRIPTION
Added reducer and container component to separate single instrument page loading from all instruments. This allows user to go directly to url with product id number/refresh page and fixes the top 5 options on the homepage.