### PR TITLE
add to cart and remove from cart functionality

### DIFF
--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -20,9 +20,9 @@ export default class Cart extends React.Component {
           <Header as="h2" textAlign="center" style={{marginTop: '10px'}}>Your Cart</Header>
             <Grid>
               <Grid.Row textAlign="center">
-                {(cart && cart.length ?
+                {(cart.items && cart.items.length ?
                   (<Container>
-                    {cart.map(item => {
+                    {cart.items.map(item => {
                     let singleItem = this.props.instruments.find(instrument => instrument.id === +item.id)
                     return (
                       <Grid celled key={item.id}>
@@ -40,10 +40,19 @@ export default class Cart extends React.Component {
                             <h3>Quantity:{
                             item.quantity}</h3>
                           </Grid.Row>
+                          <Grid.Row>
+                            <Button animated color="red" size= "small" onClick={() => this.props.removeFromCart(cart.id, singleItem, cart.items)}>
+                              <Button.Content visible>Remove from Cart</Button.Content>
+                              <Button.Content hidden>
+                                <Icon name="remove circle" size="large" />
+                              </Button.Content>
+                            </Button>
+                            </Grid.Row>
                         </Grid.Column>
                       </Grid>
                     )
                   })}
+                    <Header as="h2"> Total:</Header>
                     <Button.Group widths={5}>
                       <Button as={Link} to="/instruments" color="yellow" size="large">
                       Take me back to the shop

--- a/client/components/SingleInstrument.js
+++ b/client/components/SingleInstrument.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Dropdown, Image, Grid, Icon, Button, Rating } from 'semantic-ui-react';
-import { postCart } from '../store';
 
 const options = [
     { key: 1, text: "1", value: 1 },
@@ -10,7 +9,6 @@ const options = [
     { key: 4, text: "4", value: 4 },
     { key: 5, text: "5", value: 5 }
 ]
-//
 
 export default class SingleInstrument extends React.Component {
 
@@ -19,6 +17,7 @@ export default class SingleInstrument extends React.Component {
         if (this.props.loadInstrument) {
             this.props.loadInstrument();
         }
+        this.props.loadCart();
     }
 
     render() {
@@ -60,7 +59,7 @@ export default class SingleInstrument extends React.Component {
                           let currentItem = {
                             id: +singleInstrument.id, price: +singleInstrument.price, quantity: 1
                           }
-                          cart.length ? this.props.addToCart(currentItem) : this.props.createCart(currentItem)}}>
+                          cart.items && cart.items.length ? this.props.addToCart(cart.id, currentItem, cart.items) : this.props.createCart(currentItem)}}>
                           <Icon name="add to cart" size="large" color="teal" />
                         </Button>
                       </h3>

--- a/client/containers/CartContainer.js
+++ b/client/containers/CartContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import Cart from '../components/Cart';
-import { fetchCart, fetchInstruments } from '../store';
+import { fetchCart, fetchInstruments, putRemoveFromCart } from '../store';
 
 const mapStateToProps = (storeState) => ({
     cart: storeState.cart,
@@ -15,6 +15,10 @@ const mapDispatchToProps = (dispatch) => ({
   },
   loadInstruments: () => {
     const action = fetchInstruments();
+    return dispatch(action);
+  },
+  removeFromCart: (cartId, itemToRemove, currentCartItems) => {
+    const action = putRemoveFromCart(cartId, itemToRemove, currentCartItems);
     return dispatch(action);
   }
 });

--- a/client/containers/SingleInstrumentContainer.js
+++ b/client/containers/SingleInstrumentContainer.js
@@ -13,8 +13,12 @@ const mapStateToProps = (storeState, ownProps) => ({
       const action = fetchSingleInstrument(+(ownProps.match.params.id));
       return dispatch(action);
     },
-    addToCart: (item) => {
-      const action = putAddToCart(item);
+    loadCart: () => {
+      const action = fetchCart();
+      return dispatch(action);
+    },
+    addToCart: (cartId, itemToAdd, currentCartItems) => {
+      const action = putAddToCart(cartId, itemToAdd, currentCartItems);
       return dispatch(action);
     },
     createCart: (item) => {

--- a/client/store/reducers/cart.js
+++ b/client/store/reducers/cart.js
@@ -60,10 +60,13 @@ export const postCart = item => {
   };
 };
 
-export const putAddToCart = itemToAdd => {
+export const putAddToCart = (cartId, itemToAdd, currentCartItems) => {
   return dispatch => {
     return axios
-      .put(`/api/cart/add`, itemToAdd)
+      .put(`/api/cart/`, {
+        id: cartId,
+        items: currentCartItems.concat([itemToAdd])
+      })
       .then(res => res.data)
       .then(cart => {
         const action = addToCart(cart);
@@ -73,10 +76,13 @@ export const putAddToCart = itemToAdd => {
   }
 }
 
-export const putRemoveFromCart = itemToRemove => {
+export const putRemoveFromCart = (cartId, itemToRemove, currentCartItems) => {
   return dispatch => {
     return axios
-      .put(`/api/cart/remove`, itemToRemove)
+      .put(`/api/cart`, {
+        id: cartId,
+        items: currentCartItems.filter(item => item.id !== itemToRemove.id)
+      })
       .then(res => res.data)
       .then(cart => {
         const action = removeFromCart(cart);
@@ -87,12 +93,12 @@ export const putRemoveFromCart = itemToRemove => {
 }
 
 //REDUCER
-export default function cartReducer(state = [], action) {
+export default function cartReducer(state = {}, action) {
   switch (action.type) {
     case ADD_TO_CART:
-      return [...state, action.item];
+      return state.items.concat([action.item]);
     case REMOVE_FROM_CART:
-      return state.filter(item => item.id !== action.item.id);
+      return state.items.filter(item => item.id !== action.item.id);
     case GET_CART:
       return action.cart;
     case CLEAR_CART:
@@ -103,3 +109,4 @@ export default function cartReducer(state = [], action) {
       return state;
   }
 }
+

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -1,38 +1,12 @@
 const router = require('express').Router();
 const { Order } = require('../db/models');
 
-router.put('/add', (req, res, next) => {
-  let userId = req.user ? req.user.id : null;
-  let sessionId = req.session.id;
-  if (req.user) {
-    Order.update({
-      userId: userId,
-      sessionId: sessionId,
-      items: [req.body]
-    }, {
-        where: {
-          fulfilled: false,
-          userId: req.user.id
-        }
-      }
-    )
-      .then(cart => res.status(200).json(cart))
-      .catch(next);
-  } else {
-    Order.update({
-      userId: userId,
-      sessionId: sessionId,
-      items: [req.body]
-    }, {
-        where: {
-          fulfilled: false,
-          sessionId: req.session.id
-        }
-      }
-    )
-      .then(cart => res.status(200).json(cart))
-      .catch(next);
-  }
+router.put(`/`, (req, res, next) => {
+  Order.findById(req.body.id)
+  .then(order => order.update(req.body))
+  .then(updatedOrder => {
+    res.status(200).json(updatedOrder);
+  })
 })
 
 router.get('/', (req, res, next) => {
@@ -55,7 +29,7 @@ router.get('/', (req, res, next) => {
   foundOrder
     .then(orderObj => {
       if (orderObj) {
-        res.status(200).json(orderObj.items);
+        res.status(200).json(orderObj);
       } else {
         res.sendStatus(404);
       }


### PR DESCRIPTION
can now add to cart from single instrument pages (to a new or existing cart) & set up remove from cart functionality. Need to fix the remove from cart because currently the functionality works but when you click remove from cart it shows "you're cart is now empty" and you need to do a hard refresh to get it to show the actual rest of the items left in the cart